### PR TITLE
Fix Makefile $(REBAR) variable handling on Illumos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: doc compile test compile_test clean_test run_test escriptize deps
 
-REBAR ?= $(shell which rebar || echo ./rebar)
+REBAR ?= $(shell test -e `which rebar` 2>/dev/null && which rebar || echo "./rebar")
 
 TESTDIRS= xtest/testapp-1 xtest/testapp-2
 


### PR DESCRIPTION
On solaris flavors, `which` has sometimes poor behavior of
not returning proper exit codes or printing errors to STDOUT
rather than STDERR.  All of this is to say, the makefile didn't
behave correctly on Solaris. $(REBAR) ended up being set to
"rebar not found" which made the compile target less than happy.
